### PR TITLE
Add type conversion of basic types to avoid crashing

### DIFF
--- a/rclpy_message_converter/rclpy_message_converter/message_converter.py
+++ b/rclpy_message_converter/rclpy_message_converter/message_converter.py
@@ -45,6 +45,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import AbstractSequence
+from rosidl_parser.definition import INTEGER_TYPES, FLOATING_POINT_TYPES, CHARACTER_TYPES, BOOLEAN_TYPE, OCTET_TYPE
 
 from builtin_interfaces.msg import Time
 from builtin_interfaces.msg import Duration
@@ -118,7 +119,19 @@ def convert_dictionary_to_ros_message(message_type, dictionary, kind='message', 
 def _convert_to_ros_type(field_name, field_type, field_value, strict_mode=True,
                          check_missing_fields=False, check_types=True):
     if isinstance(field_type, BasicType):
-        pass
+        type_name = field_type.typename
+        if type_name in INTEGER_TYPES:
+            field_value = int(field_value)
+        elif type_name in FLOATING_POINT_TYPES:
+            field_value = float(field_value)
+        elif type_name in CHARACTER_TYPES:
+            field_value = str(field_value)
+        elif type_name == BOOLEAN_TYPE:
+            field_value = bool(field_value)
+        elif type_name == OCTET_TYPE:
+            field_value = bytes(field_value)
+        else:
+            raise ValueError('Unknown basic type "{}".'.format(type_name))
     elif isinstance(field_type, NamedType):
         pass
     elif isinstance(field_type, AbstractGenericString):


### PR DESCRIPTION
If data don't match the type of the ros message field, the program dies ungracefully.
Cast the types to avoid this